### PR TITLE
Add 2-opt move to Local Search

### DIFF
--- a/src/heuristic_1.jl
+++ b/src/heuristic_1.jl
@@ -3,7 +3,7 @@ include("minimum_profit.jl")
 include("local_search.jl")
 include("optimizer.jl")
 using DotEnv, .minimum_profit, DelimitedFiles, .local_search, .optimizer
-DotEnv.load()
+DotEnv.load!()
 #Nearest Neighbor-type Heuristic
 
 function nearest_neighbor_heuristic(cities_file::AbstractString, distances::Array)
@@ -50,12 +50,16 @@ function nearest_neighbor_heuristic(cities_file::AbstractString, distances::Arra
     penalties = cities[:, 3]
 
     # Local Search improvement
-    improved_travel_cost, h1_ls_time = local_search.node_swap(cities_file, total_travel_cost, recollected_prize, I, distances)
-
+    # Swap
+    swapped_tour, improved_travel_cost, h1_ls_time = local_search.node_swap(cities_file, total_travel_cost, recollected_prize, I, distances)
+    println(swapped_tour, " H1 swapped cost ", improved_travel_cost)
+    # 2-opt
+    two_opt_solution, improved_opt_cost, h1_opt_time = local_search.two_opt_move(swapped_tour, distances, prizes, penalties, minimum_profit)
+    println(two_opt_solution, " H1 2-opt cost ", improved_opt_cost)
     # Call the gurobi_optimizer function
     optimal_value, gurobi_time = optimizer.gurobi_optimizer(distances, minimum_profit, prizes, penalties)
 
-    return total_travel_cost, improved_travel_cost, optimal_value, h1_ls_time, gurobi_time
+    return total_travel_cost, improved_opt_cost, optimal_value, h1_ls_time, gurobi_time
 end
 
 end

--- a/src/heuristic_2.jl
+++ b/src/heuristic_2.jl
@@ -3,7 +3,7 @@ include("minimum_profit.jl")
 include("local_search.jl")
 include("optimizer.jl")
 using DotEnv, .minimum_profit, DelimitedFiles, .local_search, .optimizer
-DotEnv.load()
+DotEnv.load!()
 # Cheapest Insertion-type Heuristic
 
 function cheapest_insertion_heuristic(cities_file::AbstractString, distances::Array)
@@ -54,12 +54,16 @@ function cheapest_insertion_heuristic(cities_file::AbstractString, distances::Ar
     penalties = cities[:, 3]
 
     # Local Search improvement
-    improved_travel_cost, h2_ls_time = local_search.node_swap(cities_file, total_travel_cost, recollected_prize, I, distances)
-
+    # Swap
+    swapped_tour, improved_travel_cost, h2_ls_time = local_search.node_swap(cities_file, total_travel_cost, recollected_prize, I, distances)
+    println(swapped_tour, " H2 swapped cost ", improved_travel_cost)
+    # 2-opt
+    two_opt_solution, improved_opt_cost, h2_opt_time = local_search.two_opt_move(swapped_tour, distances, prizes, penalties, minimum_profit)
+    println(two_opt_solution, " H2 2-opt cost ", improved_opt_cost)
     # Call the gurobi_optimizer function
     #optimal_value, optimality_gap, gurobi_time = optimizer.gurobi_optimizer(distances, minimum_profit, prizes, penalties, total_travel_cost)
 
-    return total_travel_cost, improved_travel_cost, h2_ls_time
+    return total_travel_cost, improved_opt_cost, h2_ls_time
 end
 
 end

--- a/src/local_search.jl
+++ b/src/local_search.jl
@@ -1,7 +1,7 @@
 module local_search
 include("minimum_profit.jl")
 using DotEnv, .minimum_profit, DelimitedFiles, Statistics
-DotEnv.load()
+DotEnv.load!()
 #Nearest Neighbor-type Heuristic
 
 function node_swap(cities_file::AbstractString, total_travel_cost::Int64, recollected_prize::Int, I::Array, distances::Array)
@@ -11,7 +11,7 @@ function node_swap(cities_file::AbstractString, total_travel_cost::Int64, recoll
     minimum_profit = calculate_minimum_profit(cities)
 
     n = size(cities, 1)
-    
+
     new_travel_cost = 0
 
     able_to_replace = copy((I))
@@ -35,12 +35,12 @@ function node_swap(cities_file::AbstractString, total_travel_cost::Int64, recoll
                 break
             else
                 city_to_remove = cities[rand(able_to_replace), :]
-        
+
                 cities_to_add_candidates = setdiff(cities[:, 1], I)
                 city_to_add = cities[rand(cities_to_add_candidates), :]
             end
-        end    
-        
+        end
+
         # Calculate the indices of the city to remove and add
         idx = findall(x -> x == city_to_remove[1], I)
 
@@ -48,13 +48,13 @@ function node_swap(cities_file::AbstractString, total_travel_cost::Int64, recoll
         if idx[1] == 1
             prev_city = I[end]
         else
-            prev_city = I[idx[1] - 1]
+            prev_city = I[idx[1]-1]
         end
 
         if idx[end] == length(I)
             next_city = I[1]
         else
-            next_city = I[idx[end] + 1]
+            next_city = I[idx[end]+1]
         end
 
         # Update the tour_travel_cost variable
@@ -66,9 +66,9 @@ function node_swap(cities_file::AbstractString, total_travel_cost::Int64, recoll
         # Adjust the new_travel_cost by the penalties of the cities removed and added
         new_travel_cost = new_travel_cost - city_to_add[3] + city_to_remove[3]
 
-        if (total_travel_cost > new_travel_cost) && (new_prize >=minimum_profit)
+        if (total_travel_cost > new_travel_cost) && (new_prize >= minimum_profit)
             # Perform the swap in the tour I
-            replace!(I, city_to_remove[1]=>city_to_add[1])
+            replace!(I, city_to_remove[1] => city_to_add[1])
 
             able_to_replace = setdiff(able_to_replace, city_to_remove[1])
             if isempty(able_to_replace)
@@ -90,8 +90,56 @@ function node_swap(cities_file::AbstractString, total_travel_cost::Int64, recoll
     heuristic_end_time = time()
     heuristic_execution_time = heuristic_end_time - heuristic_start_time
 
-    return total_travel_cost, heuristic_execution_time
+    return I, total_travel_cost, heuristic_execution_time
 
+end
+
+function two_opt_move(tour::Vector{Int}, distances::Matrix{Int64}, prizes::Vector{Int64},
+    penalties::Vector{Int64}, minimum_profit::Int64)
+    n = length(tour)
+    improved = true
+    total_prize = sum(prizes[tour])
+    total_cost = calculate_tour_cost(tour, distances, penalties)
+
+    heuristic_start_time = time()
+    while improved
+        improved = false
+        for i in 1:n-2
+            for j in i+2:n-1  # Ensure we don't reverse the entire tour
+                # Create new tour with reversed segment
+                new_tour = copy(tour)
+                reverse!(new_tour, i + 1, j)
+
+                # Calculate new cost and prize
+                new_cost = calculate_tour_cost(new_tour, distances, penalties)
+                new_prize = sum(prizes[new_tour])
+
+                # Check if the new tour is better and meets the minimum profit
+                if new_cost < total_cost && new_prize >= minimum_profit
+                    tour .= new_tour
+                    total_cost = new_cost
+                    total_prize = new_prize
+                    improved = true
+                    break
+                end
+            end
+            if improved
+                break
+            end
+        end
+    end
+
+    heuristic_end_time = time()
+    heuristic_execution_time = heuristic_end_time - heuristic_start_time
+
+    return tour, total_cost, heuristic_execution_time
+end
+
+function calculate_tour_cost(tour::Vector{Int}, distances::Matrix{Int64}, penalties::Vector{Int64})
+    cost = sum(distances[tour[i], tour[i+1]] for i in 1:length(tour)-1)
+    cost += distances[tour[end], tour[1]]  # Return to start
+    cost += sum(penalties[setdiff(1:length(penalties), tour)])  # Add penalties for unvisited cities
+    return cost
 end
 
 end

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -51,8 +51,8 @@ function gurobi_optimizer(c::Matrix{Int64}, w0::Int64, prizes::Vector{Int64}, pe
     end
 
     # Get the best bound value
-    optimal_value = dual_objective_value(model)
-
+    best_bound_value = dual_objective_value(model)
+    optimal_value = objective_value(model)
     # Calculate the optimality gap
     #optimality_gap = (abs(total_travel_cost - optimal_value) / abs(total_travel_cost)) * 100
 
@@ -67,9 +67,9 @@ function gurobi_optimizer(c::Matrix{Int64}, w0::Int64, prizes::Vector{Int64}, pe
     #println(x)
     #println(y)
     gurobi_sol = interpret_gurobi_pctsp_solution(x, y)
-    @show gurobi_sol
+    @show gurobi_sol, optimal_value
 
-    return optimal_value, execution_time
+    return best_bound_value, execution_time
 end
 
 function interpret_gurobi_pctsp_solution(x::Matrix{Int64}, y::Vector{Int64}, threshold::Float64=0.5)


### PR DESCRIPTION
This PR adds the 2-opt move defined in literature for the TSP and a minor fix to a variable in the Optimizer. 

**Do note that it will break previous versions of DotEnv as the load() method was changed to load!()** so prepare accordingly.

The 2-opt move is defined as follows:

Input:
  tour: current tour (list of city indices)
  distances: matrix of distances between cities
  prizes: list of prizes for each city
  penalties: list of penalties for not visiting each city
  minimum_profit: minimum required total prize

Output:
  optimized_tour: improved tour after 2-opt moves
  final_cost: cost of the optimized tour

Initialize:
  improved = true
  total_prize = sum of prizes for cities in tour
  total_cost = CalculateTourCost(tour, distances, penalties)

While improved:
  improved = false
  For i = 1 to length(tour) - 2:
    For j = i + 2 to length(tour) - 1:
      new_tour = Copy of tour
      Reverse the segment of new_tour from index i+1 to j
      
      new_cost = CalculateTourCost(new_tour, distances, penalties)
      new_prize = Sum of prizes for cities in new_tour
      
      If new_cost < total_cost AND new_prize >= minimum_profit:
        tour = new_tour
        total_cost = new_cost
        total_prize = new_prize
        improved = true
        Break inner loop
    
    If improved:
      Break outer loop

Return tour, total_cost

Function CalculateTourCost(tour, distances, penalties):
  cost = Sum of distances between consecutive cities in tour
  cost += Distance from last city back to first city
  cost += Sum of penalties for cities not in tour
  Return cost
